### PR TITLE
Slight improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # Memory Allocator in C
 
-A basic memory allocator written in C. Allocates memory through the `mmap()` and `munmap()` system calls.
+A basic memory allocator written in C. Allocates memory through the `sbrk()' system calls.
 
 It implements `malloc()`, `calloc()`, `realloc()` and `free()`, check the [manual](https://man7.org/linux/man-pages/man3/free.3.html) for details on the native implementation of these functions.
-
-For more details on the `mmap()` system call, check the manual page (e.g. `man 2 mmap`) for more details.
 
 ## mmap() v.s. brk()/sbrk()
 
 The actual `malloc()` in *libc* implements memory allocation through both the `brk()/sbrk()` and `mmap()` system calls interchangably. Checking `man 2 sbrk` on a mac book terminal: *"The brk and sbrk functions are historical curiosities left over from earlier days before the advent of virtual memory management."*.
 
-In general, `mmap()` is safer than `brk()` (brk/sbrk are not thread-safe). Normally `mmap()` is used to allocate a larger chunk of memory, and it can be more efficient to use the `brk()` system call to implement this allocator due to it's less complex nature. For learning purposes and safety reasons, `mmap()` is used instead of `brk()` for the implementation.  
+In general, `mmap()` is safer than `sbrk()` (brk/sbrk are not thread-safe). Normally `mmap()` is used to allocate a larger chunk of memory, and it can be more efficient to use the `sbrk()` system call to implement this allocator due to it's less complex nature. For simplicity, this allocator uses `sbrk()`.
+
+## Thread safety
+
+While this allocator attempts to be thread-safe with a mutex, it is not guaranteed to be so. This is due to 
+to the fact that the `sbrk()` system call itself is not thread-safe. So a thread can call `sbrk()` and change the heap size while another thread is in the middle of a `mymalloc()` call. This can lead to memory corruption.
+
+This allocator is written for fun only and is far from "correct" and "perfect"!

--- a/main.c
+++ b/main.c
@@ -21,7 +21,7 @@ int main(int argc, char **argv)
 {
     if (argc < 2)
     {
-        printf("Usage: %s <number of integers>\n", argv[0]);
+        printf("Usage: %s <number of integers in array>\n", argv[0]);
         return 1;
     }
     int n = atoi(argv[1]);

--- a/mymalloc.h
+++ b/mymalloc.h
@@ -1,7 +1,7 @@
 #ifndef MYMALLOC_H
 #define MYMALLOC_H
 
-typedef struct block block_t;
+typedef union block block_t;
 
 block_t *get_free_block(size_t size);
 


### PR DESCRIPTION
Changed from using mmap to using sbrk (simplicity and efficiency).
mmap only maps PAGE_SIZE byte pages, which can be inefficient and cause fragmentation for this little "done-for-fun" allocator.

Also changed the header struct to a union so that a 16 byte alignment for the block headers can be forced.